### PR TITLE
Add tag deploy with require

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,17 @@ workflows:
             branches:
               ignore:
                 - master
-
       - deploy_dev:
           requires:
             - test
           filters:
             branches:
               only: master
+      - deploy_tag:
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 CircleCI is being weird. Time for a test.
 
 
-Latest release: v0.1.0
+Latest release: v0.1.1


### PR DESCRIPTION
The expected result is, we don't get a deploy, because CircleCI has a strange constraint that the "test" job we require also has the same filter.